### PR TITLE
Prevent space under footer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,11 @@
   <header>
     <h1>eirb.fr</h1>
     <h2>Services, clubs & associations de l'ENSEIRB-MATMECA</h2>
-  </header>
 
-  <div class="triangle-wrapper">
-    <div class="triangle-right"></div>
-  </div>
+    <div class="triangle-wrapper">
+      <div class="triangle-right"></div>
+    </div>
+  </header>
 
   <main>
     <HomeView />

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -57,8 +57,8 @@ body {
 #app {
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: min-content auto min-content;
-  height: 100%;
+  grid-template-rows: min-content 1fr min-content;
+  min-height: 100vh;
   // overflow-x: hidden;
   box-sizing: border-box;
 }

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -64,30 +64,25 @@ body {
 }
 
 header {
-  background-color: var(--primary-color);
   padding-top: 20px;
-  padding-bottom: 20px;
-  text-align: center;
-  font-weight: bold;
-  color: #ffffff;
-  position: relative;
-  width: 100%;
-  box-sizing: border-box;
+  background-color: var(--primary-color);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
 
   h1 {
-    margin: 0 auto;
     font-size: 42px;
     background-color: #fff;
     color: var(--primary-color);
     width: fit-content;
     padding: 8px 16px;
-    position: relative;
-    z-index: 0;
   }
 
-  h2 {
-    margin: 20px auto 0 auto;
-  }
+  h2 { color: #fff; }
+
+  h1, h2 { margin: 0; }
 }
 
 main {


### PR DESCRIPTION
Problème pouvant arriver lorsqu'on ne recherche que "occ" dans la barre de recherche, la page était trop petite et un espace blanc apparaissait en dessous du footer.

Il y a un *léger* refactor du CSS permettant d'accepter le "triangle" du header dans la balise header, en ayant le style du header plus lisible.