### PR TITLE
Channel buttons

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       gsap:
         specifier: ^3.12.5
         version: 3.12.5
-      party-js:
-        specifier: ^2.2.0
-        version: 2.2.0
       vue:
         specifier: ^3.4.29
         version: 3.4.32(typescript@5.4.5)
@@ -970,9 +967,6 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
-
-  party-js@2.2.0:
-    resolution: {integrity: sha512-50hGuALCpvDTrQLPQ1fgUgxKIWAH28ShVkmeK/3zhO0YJyCqkhrZhQEkWPxDYLvbFJ7YAXyROmFEu35gKpZLtQ==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -2147,8 +2141,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  party-js@2.2.0: {}
 
   path-browserify@1.0.1: {}
 

--- a/src/assets/links/assos.ts
+++ b/src/assets/links/assos.ts
@@ -12,10 +12,10 @@ const assos: LinkGroup = {
       url: 'https://bde.eirb.fr/',
       icon: 'associations/x128/bde.png',
       additionalLink: {
-        url: protectRedirectURL("telegramBDE"),
+        url: protectRedirectURL('telegramBDE'),
         type: AdditionalLinkType.TELEGRAM,
-        description: "Telegram BDE"
-      }
+        description: 'Telegram officiel du BDE',
+      },
     },
     {
       name: 'BDS',
@@ -23,10 +23,10 @@ const assos: LinkGroup = {
       url: 'https://bds.eirb.fr/',
       icon: 'associations/x128/bds.png',
       additionalLink: {
-        url: protectRedirectURL("telegramBDS"),
+        url: protectRedirectURL('telegramBDS'),
         type: AdditionalLinkType.TELEGRAM,
-        description: "Canal des escrocs"
-      }
+        description: 'Canal des escrocs',
+      },
     },
     {
       name: 'BDA',
@@ -34,10 +34,10 @@ const assos: LinkGroup = {
       url: 'https://bda.eirb.fr/',
       icon: 'associations/x128/bda.png',
       additionalLink: {
-        url: protectRedirectURL("linktreeBDA"),
+        url: protectRedirectURL('linktreeBDA'),
         type: AdditionalLinkType.LINKTREE,
-        description: "Linktree du meilleur Bureau"
-      }
+        description: 'Linktree du meilleur Bureau',
+      },
     },
     {
       name: 'BAE',
@@ -45,10 +45,10 @@ const assos: LinkGroup = {
       url: 'https://bae.eirb.fr/',
       icon: 'associations/x128/bae.png',
       additionalLink: {
-        url: protectRedirectURL("telegramBAE"),
+        url: protectRedirectURL('telegramBAE'),
         type: AdditionalLinkType.TELEGRAM,
-        description: "Telegram BAE"
-      }
+        description: 'Telegram officiel du BAE',
+      },
     },
     {
       name: 'Le Bar',
@@ -56,51 +56,76 @@ const assos: LinkGroup = {
       url: 'https://bar.eirb.fr/',
       icon: 'associations/x128/bar.png',
       additionalLink: {
-        url: protectRedirectURL("telegramBAR"),
+        url: protectRedirectURL('telegramBAR'),
         type: AdditionalLinkType.TELEGRAM,
-        description: "Telegram BAR"
-      }
+        description: 'Le channel du Q',
+      },
     },
     {
       name: 'Eirbware',
       description: "Association d'assistance et formation informatique",
       url: 'https://eirbware.eirb.fr/',
       icon: 'associations/x128/eirbware.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirbware'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirbware",
+      },
     },
     {
       name: 'AEI',
       description: 'Junior Entreprise',
       url: 'https://aei.eirb.fr/',
+      icon: 'associations/x128/aei.png',
       additionalLink: {
         description: 'Linktree AEI',
         url: protectRedirectURL('linktreeAEI'),
         type: AdditionalLinkType.LINKTREE,
       },
-      icon: 'associations/x128/aei.png',
     },
     {
       name: 'Eirbot',
       description: 'Association de robotique',
       url: 'https://eirbot.eirb.fr/',
       icon: 'associations/x128/eirbot.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirbot'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirbot",
+      },
     },
     {
       name: 'EirLab',
       description: 'Fablab',
       url: 'https://eirlab.eirb.fr/',
       icon: 'associations/x128/eirlab.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirlab'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirlab",
+      },
     },
     {
       name: 'EirSport',
       description: 'Association multisport',
       url: 'https://eirsport.eirb.fr/',
       icon: 'associations/x128/eirsport.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirsport'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirsport",
+      },
     },
     {
       name: 'EirSpace',
       description: "Association d'aérospatial",
       url: 'https://eirspace.eirb.fr/',
       icon: 'associations/x128/eirspace.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirspace'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'EirbSpace",
+      },
     },
     {
       name: "Gala Mos'fête",

--- a/src/assets/links/assos.ts
+++ b/src/assets/links/assos.ts
@@ -11,30 +11,55 @@ const assos: LinkGroup = {
       description: 'Bureau des élèves',
       url: 'https://bde.eirb.fr/',
       icon: 'associations/x128/bde.png',
+      additionalLink: {
+        url: protectRedirectURL("telegramBDE"),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram BDE"
+      }
     },
     {
       name: 'BDS',
       description: 'Bureau des sports',
       url: 'https://bds.eirb.fr/',
       icon: 'associations/x128/bds.png',
+      additionalLink: {
+        url: protectRedirectURL("telegramBDS"),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Canal des escrocs"
+      }
     },
     {
       name: 'BDA',
       description: 'Bureau des arts',
       url: 'https://bda.eirb.fr/',
       icon: 'associations/x128/bda.png',
+      additionalLink: {
+        url: protectRedirectURL("linktreeBDA"),
+        type: AdditionalLinkType.LINKTREE,
+        description: "Linktree du meilleur Bureau"
+      }
     },
     {
       name: 'BAE',
       description: 'Bureau des alternants',
       url: 'https://bae.eirb.fr/',
       icon: 'associations/x128/bae.png',
+      additionalLink: {
+        url: protectRedirectURL("telegramBAE"),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram BAE"
+      }
     },
     {
       name: 'Le Bar',
       description: 'Caféteria',
       url: 'https://bar.eirb.fr/',
       icon: 'associations/x128/bar.png',
+      additionalLink: {
+        url: protectRedirectURL("telegramBAR"),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram BAR"
+      }
     },
     {
       name: 'Eirbware',

--- a/src/assets/links/assos.ts
+++ b/src/assets/links/assos.ts
@@ -1,6 +1,4 @@
-import { AdditionalLinkType, type LinkGroup } from './links';
-
-const protectRedirectURL = (id: string) => `https://eirb.fr/protect/link.php?name=${id}`;
+import { AdditionalLinkType, protectRedirectURL, type LinkGroup } from './links';
 
 const assos: LinkGroup = {
   id: 'associations',

--- a/src/assets/links/assos.ts
+++ b/src/assets/links/assos.ts
@@ -1,4 +1,6 @@
-import type { LinkGroup } from './links';
+import { AdditionalLinkType, type LinkGroup } from './links';
+
+const protectRedirectURL = (id: string) => `https://eirb.fr/protect/link.php?name=${id}`;
 
 const assos: LinkGroup = {
   id: 'associations',
@@ -44,6 +46,11 @@ const assos: LinkGroup = {
       name: 'AEI',
       description: 'Junior Entreprise',
       url: 'https://aei.eirb.fr/',
+      additionalLink: {
+        description: 'Linktree AEI',
+        url: protectRedirectURL('linktreeAEI'),
+        type: AdditionalLinkType.LINKTREE,
+      },
       icon: 'associations/x128/aei.png',
     },
     {

--- a/src/assets/links/channels.ts
+++ b/src/assets/links/channels.ts
@@ -7,45 +7,9 @@ const channels: LinkGroup = {
     name: 'Canaux',
     links: [
         {
-            name: "Linktree AEI",
-            description: "",
-            url: protectRedirectURL("linktreeAEI"),
-            icon: "links/linktree.svg"
-        },
-        {
             name: "Telegram Arte",
             description: "",
             url: protectRedirectURL("telegramArte"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram BAE",
-            description: "",
-            url: protectRedirectURL("telegramBAE"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram BAR",
-            description: "",
-            url: protectRedirectURL("telegramBAR"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Linktree BDA",
-            description: "",
-            url: protectRedirectURL("linktreeBDA"),
-            icon: "links/linktree.svg"
-        },
-        {
-            name: "Telegram BDE",
-            description: "",
-            url: protectRedirectURL("telegramBDE"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram BDS",
-            description: "",
-            url: protectRedirectURL("telegramBDS"),
             icon: "links/telegram.svg"
         },
         {

--- a/src/assets/links/channels.ts
+++ b/src/assets/links/channels.ts
@@ -1,10 +1,8 @@
-import type { LinkGroup } from './links';
-
-const protectRedirectURL = (id: string) => `https://eirb.fr/protect/link.php?name=${id}`;
+import { protectRedirectURL, type LinkGroup } from './links';
 
 const channels: LinkGroup = {
     id: 'channels',
-    name: 'Canaux',
+    name: 'Canaux des autres Organisations',
     links: [
         {
             name: "Telegram Arte",
@@ -17,12 +15,6 @@ const channels: LinkGroup = {
             description: "",
             url: protectRedirectURL("telegramBINKS"),
             icon: "links/linktree.svg"
-        },
-        {
-            name: "Telegram Billeirb",
-            description: "",
-            url: protectRedirectURL("telegramBilleirb"),
-            icon: "links/telegram.svg"
         },
         {
             name: "Telegram Bouquin'eirb",
@@ -40,36 +32,6 @@ const channels: LinkGroup = {
             name: "Telegram CluBee",
             description: "",
             url: protectRedirectURL("telegramCluBee"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Théâtre",
-            description: "",
-            url: protectRedirectURL("telegramTheatre"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Zik",
-            description: "",
-            url: protectRedirectURL("telegramZik"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Oeno",
-            description: "",
-            url: protectRedirectURL("telegramOeno"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Cook'eirb",
-            description: "",
-            url: protectRedirectURL("telegramCook"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Couturi'eirb",
-            description: "",
-            url: protectRedirectURL("telegramCouturieirb"),
             icon: "links/telegram.svg"
         },
         {
@@ -97,21 +59,9 @@ const channels: LinkGroup = {
             icon: "links/telegram.svg"
         },
         {
-            name: "Telegram Eirb'ia",
-            description: "",
-            url: protectRedirectURL("telegramEirbia"),
-            icon: "links/telegram.svg"
-        },
-        {
             name: "Telegram Eirbees",
             description: "",
             url: protectRedirectURL("telegramEirbees"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Eirbline",
-            description: "",
-            url: protectRedirectURL("telegramEirbline"),
             icon: "links/telegram.svg"
         },
         {
@@ -142,12 +92,6 @@ const channels: LinkGroup = {
             name: "Discord Foyer",
             description: "",
             url: protectRedirectURL("discordFoyer"),
-            icon: "links/discord.svg"
-        },
-        {
-            name: "Discord GCC",
-            description: "",
-            url: protectRedirectURL("discordGCC"),
             icon: "links/discord.svg"
         },
         {
@@ -199,12 +143,6 @@ const channels: LinkGroup = {
             icon: "links/telegram.svg"
         },
         {
-            name: "Telegram Pixeirb",
-            description: "",
-            url: protectRedirectURL("telegramPixeirb"),
-            icon: "links/telegram.svg"
-        },
-        {
             name: "Telegram Planet'eirb",
             description: "",
             url: protectRedirectURL("telegramPlaneteirb"),
@@ -232,18 +170,6 @@ const channels: LinkGroup = {
             name: "Telegram Supporteirb",
             description: "",
             url: protectRedirectURL("telegramSupporteirb"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Discord Unlock",
-            description: "",
-            url: protectRedirectURL("discordUnlock"),
-            icon: "links/discord.svg"
-        },
-        {
-            name: "Telegram Vost",
-            description: "",
-            url: protectRedirectURL("telegramVost"),
             icon: "links/telegram.svg"
         },
     ],

--- a/src/assets/links/channels.ts
+++ b/src/assets/links/channels.ts
@@ -97,24 +97,6 @@ const channels: LinkGroup = {
             icon: "links/telegram.svg"
         },
         {
-            name: "Telegram Eirlab",
-            description: "",
-            url: protectRedirectURL("telegramEirlab"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Eirspace",
-            description: "",
-            url: protectRedirectURL("telegramEirspace"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Eirsport",
-            description: "",
-            url: protectRedirectURL("telegramEirsport"),
-            icon: "links/telegram.svg"
-        },
-        {
             name: "Telegram Eirb'ia",
             description: "",
             url: protectRedirectURL("telegramEirbia"),
@@ -130,18 +112,6 @@ const channels: LinkGroup = {
             name: "Telegram Eirbline",
             description: "",
             url: protectRedirectURL("telegramEirbline"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Eirbot",
-            description: "",
-            url: protectRedirectURL("telegramEirbot"),
-            icon: "links/telegram.svg"
-        },
-        {
-            name: "Telegram Eirbware",
-            description: "",
-            url: protectRedirectURL("telegramEirbware"),
             icon: "links/telegram.svg"
         },
         {

--- a/src/assets/links/club.ts
+++ b/src/assets/links/club.ts
@@ -1,4 +1,4 @@
-import type { LinkGroup } from './links';
+import { AdditionalLinkType, protectRedirectURL, type LinkGroup } from './links';
 
 const clubs: LinkGroup = {
   id: 'clubs',
@@ -9,18 +9,33 @@ const clubs: LinkGroup = {
       description: 'Club de billard',
       url: 'https://bill.eirb.fr/',
       icon: 'associations/x128/billeirb.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramBilleirb'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel de Billeirb',
+      },
     },
     {
       name: "Cook'eirb",
       description: 'Club de cuisine',
       url: 'https://cook.eirb.fr/',
       icon: 'associations/x128/cookeirb.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramCook'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel de Cook'eirb",
+      },
     },
     {
       name: "Couturi'eirb",
       description: 'Club de couture',
       url: 'https://couturi.eirb.fr/',
       icon: 'associations/x128/couturieirb.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramCouturieirb'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel de Couturi'eirb",
+      },
     },
     {
       name: "CheriF'eirb",
@@ -33,12 +48,22 @@ const clubs: LinkGroup = {
       description: "Club d'aviation",
       url: 'https://eirbline.eirb.fr/',
       icon: 'associations/x128/eirbline.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirbline'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirbline",
+      },
     },
     {
       name: 'EMK',
       description: 'Club de Hip-Hop',
       url: 'https://emk.eirb.fr/',
       icon: 'associations/x128/emk.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEMK'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'EMK",
+      },
     },
     /*{
               "name": "Foyer",
@@ -51,16 +76,26 @@ const clubs: LinkGroup = {
       description: 'Club de création de jeux vidéo',
       url: 'https://gcc.eirb.fr/',
       icon: 'associations/x128/gcc.png',
+      additionalLink: {
+        url: protectRedirectURL('discordGCC'),
+        type: AdditionalLinkType.DISCORD,
+        description: 'Discord officie GCC',
+      },
     },
     {
       name: "Eirb'IA",
       description: "Club d'intelligence artificielle",
       url: 'https://ia.eirb.fr/',
       icon: 'associations/x128/eirbia.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramEirbia'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: "Telegram officiel d'Eirb'IA",
+      },
     },
     {
       name: "Nlog'eirb",
-      description: "Club de programmation compétitive",
+      description: 'Club de programmation compétitive',
       url: 'https://nlog.eirb.fr/',
       icon: 'associations/x128/nlogeirb.png',
     },
@@ -69,36 +104,66 @@ const clubs: LinkGroup = {
       description: "Club d'œnologie",
       url: 'https://oeno.eirb.fr/',
       icon: 'associations/x128/oeno.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramOeno'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel du club Œno',
+      },
     },
     {
       name: 'PixEirb',
       description: 'Club de photographie',
       url: 'https://pix.eirb.fr/',
       icon: 'associations/x128/pixeirb.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramPixeirb'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel de PixEirb',
+      },
     },
     {
       name: 'Club Théâtre',
       description: 'Club de théâtre',
       url: 'https://theatre.eirb.fr/',
       icon: 'associations/x128/theatre.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramTheatre'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel Du Club Théâtre',
+      },
     },
     {
       name: 'Unlock',
       description: 'Club de sécurité informatique',
       url: 'https://unlock.eirb.fr/',
       icon: 'associations/x128/unlock.png',
+      additionalLink: {
+        url: protectRedirectURL('discordUnlock'),
+        type: AdditionalLinkType.DISCORD,
+        description: "Discord officiel d'Unlock",
+      },
     },
     {
       name: 'VOST',
       description: 'Club vidéo',
       url: 'https://vost.eirb.fr/',
       icon: 'associations/x128/vost.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramVost'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel de VOST',
+      },
     },
     {
       name: 'Zik',
       description: 'Club de musique',
       url: 'https://zik.eirb.fr/',
       icon: 'associations/x128/zik.png',
+      additionalLink: {
+        url: protectRedirectURL('telegramZik'),
+        type: AdditionalLinkType.TELEGRAM,
+        description: 'Telegram officiel du Zik',
+      },
     },
   ],
 };

--- a/src/assets/links/index.ts
+++ b/src/assets/links/index.ts
@@ -1,4 +1,5 @@
 import type { Link, LinkGroup } from './links';
+import { AdditionalLinkType, getIconURIForLinkType } from './links';
 import vpn from './vpn';
 import services from './services';
 import shortcuts from './shortcut';
@@ -9,6 +10,6 @@ import channels from './channels';
 
 const links: LinkGroup[] = [vpn, services, shortcuts, assos, clubs, lists, channels];
 
-export default links;
+export { AdditionalLinkType, getIconURIForLinkType, links };
 
 export type { Link, LinkGroup };

--- a/src/assets/links/links.ts
+++ b/src/assets/links/links.ts
@@ -1,7 +1,44 @@
+enum AdditionalLinkType {
+  ANY,
+  LINKTREE,
+  TELEGRAM,
+  DISCORD,
+  INSTAGRAM,
+  WHATSAPP,
+  FACEBOOK,
+  LINKEDIN,
+  MESSENGER,
+  YOUTUBE
+}
+
+const ICON_OF_LINK_TYPES: Record<AdditionalLinkType, string> = {
+  [AdditionalLinkType.DISCORD]: 'discord.svg',
+  [AdditionalLinkType.INSTAGRAM]: 'instagram.svg',
+  [AdditionalLinkType.LINKTREE]: 'linktree.svg',
+  [AdditionalLinkType.TELEGRAM]: 'telegram.svg',
+  [AdditionalLinkType.WHATSAPP]: 'whatsapp.svg',
+  [AdditionalLinkType.FACEBOOK]: 'facebook.svg',
+  [AdditionalLinkType.LINKEDIN]: 'linkedin.svg',
+  [AdditionalLinkType.MESSENGER]: 'messenger.svg',
+  [AdditionalLinkType.ANY]: 'website.svg',
+  [AdditionalLinkType.YOUTUBE]: 'youtube.svg',
+};
+
+function getIconURIForLinkType(linkType: AdditionalLinkType) {
+  return `links/${ICON_OF_LINK_TYPES[linkType]}`;
+}
+
+interface AdditionalLink {
+  url: string;
+  description?: string;
+  type: AdditionalLinkType;
+}
+
 interface Link {
   name: string;
   description: string;
   url: string;
+  additionalLink?: AdditionalLink;
   icon: string;
 }
 
@@ -11,4 +48,5 @@ interface LinkGroup {
   links: Link[];
 }
 
-export type { Link, LinkGroup };
+export type { Link, LinkGroup, AdditionalLink };
+export { AdditionalLinkType, getIconURIForLinkType };

--- a/src/assets/links/links.ts
+++ b/src/assets/links/links.ts
@@ -8,7 +8,7 @@ enum AdditionalLinkType {
   FACEBOOK,
   LINKEDIN,
   MESSENGER,
-  YOUTUBE
+  YOUTUBE,
 }
 
 const ICON_OF_LINK_TYPES: Record<AdditionalLinkType, string> = {
@@ -48,5 +48,7 @@ interface LinkGroup {
   links: Link[];
 }
 
+const protectRedirectURL = (id: string) => `https://eirb.fr/protect/link.php?name=${id}`;
+
 export type { Link, LinkGroup, AdditionalLink };
-export { AdditionalLinkType, getIconURIForLinkType };
+export { AdditionalLinkType, getIconURIForLinkType, protectRedirectURL };

--- a/src/components/LinkCard.vue
+++ b/src/components/LinkCard.vue
@@ -1,16 +1,24 @@
 <template>
-  <a :href="link.url" :key="link.url" rel="nofollow">
-    <div class="card">
-      <img :src="'img/' + link.icon" loading="lazy" />
+  <div class="card-container">
+    <a :href="link.url" :key="link.url" rel="nofollow">
+      <div class="card">
+        <img :src="'img/' + link.icon" loading="lazy" />
 
-      <h4>{{ link.name }}</h4>
-      <p>{{ link.description }}</p>
-    </div>
-  </a>
+        <h4>{{ link.name }}</h4>
+        <p>{{ link.description }}</p>
+      </div>
+    </a>
+    <a v-if="link.additionalLink" :href="link.additionalLink.url" :key="link.additionalLink.url" rel="nofollow">
+      <div class="card-pin">
+        <img :src="'img/' + getIconURIForLinkType(link.additionalLink.type)" loading="lazy" />
+      </div>
+    </a>
+  </div>
 </template>
 
 <script setup lang="ts">
 import type { Link } from '@/assets/links/index';
+import { getIconURIForLinkType } from '@/assets/links/index';
 
 const props = defineProps<{
   link: Link;
@@ -18,10 +26,24 @@ const props = defineProps<{
 </script>
 
 <style scoped lang="scss">
-a {
-  text-decoration: none;
-  border-radius: 10px;
+.card-container {
+  position: relative;
+  /* width: 100%; */
+
+  transition:
+    transform 0.2s ease-in-out;
+  &:hover {
+    transform: translate(4px, -4px);
+  }
+  a {
+    text-decoration: none;
+    display: block;
+    border-radius: 10px;
+    width: 100%;
+  }
+
 }
+
 
 .card {
   padding: 10px;
@@ -39,12 +61,10 @@ a {
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
 
   transition:
-    transform 0.2s ease-in-out,
     box-shadow 0.2s ease-in-out;
 
   &:hover {
     box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.4);
-    transform: translate(4px, -4px);
   }
 
   img {
@@ -70,6 +90,35 @@ a {
     grid-row: 2;
 
     margin: 0;
+  }
+}
+
+.card-pin {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 0;
+  right: 0;
+  padding: 5px;
+  height: 27px;
+  width: 27px;
+  aspect-ratio: 1/1;
+  
+  border-radius: 50%;
+
+  background: none;
+  box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.4);
+  transition:
+    box-shadow 0.2s ease-in-out;
+  &:hover {
+    box-shadow: -4px 4px 10px rgba(0, 0, 0, 0.8);
+    background-color: var(--bkg-color);
+  }
+
+  img {
+    width: 25px;
+    height: 25px;
   }
 }
 </style>

--- a/src/components/LinkCard.vue
+++ b/src/components/LinkCard.vue
@@ -10,7 +10,7 @@
     </a>
     <a v-if="link.additionalLink" :href="link.additionalLink.url" :key="link.additionalLink.url" rel="nofollow">
       <div class="card-pin">
-        <img :src="'img/' + getIconURIForLinkType(link.additionalLink.type)" loading="lazy" />
+        <img :src="'img/' + getIconURIForLinkType(link.additionalLink.type)" :alt="'additional link for ' + link.name" :title="link.additionalLink.description" loading="lazy" />
       </div>
     </a>
   </div>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -64,7 +64,7 @@ import LinkGroupComponent from '@/components/LinkGroup.vue';
 import LinkCard from '@/components/LinkCard.vue';
 
 import { onBeforeEnterFn, onEnterFn, onLeaveFn } from '@/assets/animations';
-import tmpLinkGroups, { type LinkGroup, type Link } from '@/assets/links';
+import { links as tmpLinkGroups, type LinkGroup, type Link } from '@/assets/links';
 
 const linkGroups = tmpLinkGroups.filter((el) => {
   if (el.id === 'vpn') {


### PR DESCRIPTION
For the pinned assos and clubs, the channel links have been moved into an `additionalLink` field in the `Link` interface in the ts assets. The `LinkCard` vue component has been adapted.

It remains to disabled the main url of LinkCard for assos or club which has only channel url and not any website. Afterward, the addition of all the clubs and assos unpinned will be possible (actually, it is already possible without this feature).
For organizations which does not have any website, we can also set their channel link as their main url, but the best in my opinion is the first solution so the organization which has made the effort to develop a website are more visible.