### PR TITLE
Disable the BDS

### DIFF
--- a/src/assets/links/assos.ts
+++ b/src/assets/links/assos.ts
@@ -18,7 +18,6 @@ const assos: LinkGroup = {
     {
       name: 'BDS',
       description: 'Bureau des sports',
-      url: 'https://bds.eirb.fr/',
       icon: 'associations/x128/bds.png',
       additionalLink: {
         url: protectRedirectURL('telegramBDS'),

--- a/src/assets/links/club.ts
+++ b/src/assets/links/club.ts
@@ -7,7 +7,6 @@ const clubs: LinkGroup = {
     {
       name: "Bill'eirb",
       description: 'Club de billard',
-      url: 'https://bill.eirb.fr/',
       icon: 'associations/x128/billeirb.png',
       additionalLink: {
         url: protectRedirectURL('telegramBilleirb'),

--- a/src/assets/links/links.ts
+++ b/src/assets/links/links.ts
@@ -37,7 +37,7 @@ interface AdditionalLink {
 interface Link {
   name: string;
   description: string;
-  url: string;
+  url?: string;
   additionalLink?: AdditionalLink;
   icon: string;
 }

--- a/src/assets/links/lists.ts
+++ b/src/assets/links/lists.ts
@@ -25,7 +25,6 @@ const lists: LinkGroup = {
     {
       name: "Terminat'eirb",
       description: 'Liste BDS 2025/2026 perdante',
-      url: 'https://terminat.eirb.fr/',
       icon: 'lists/x128/terminateirb.png',
     },
     {
@@ -127,7 +126,6 @@ const lists: LinkGroup = {
     {
       name: "Milit'eirb",
       description: 'Liste BDS 2021/2022',
-      url: 'https://milit.eirb.fr/',
       icon: 'lists/x128/militeirb.png',
     },
     {

--- a/src/components/LinkCard.vue
+++ b/src/components/LinkCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-container">
-    <a :href="link.url" :key="link.url" rel="nofollow">
+    <a v-if="link.url?true:false" :href="link.url" :key="link.url" rel="nofollow">
       <div class="card">
         <img :src="'img/' + link.icon" loading="lazy" />
 
@@ -8,6 +8,13 @@
         <p>{{ link.description }}</p>
       </div>
     </a>
+    <div v-else class="card">
+      <img :src="'img/' + link.icon" loading="lazy" />
+
+      <h4 class="no-link">{{ link.name }}</h4>
+      <p>{{ link.description }}</p>
+    </div>
+
     <a v-if="link.additionalLink" :href="link.additionalLink.url" :key="link.additionalLink.url" rel="nofollow">
       <div class="card-pin">
         <img :src="'img/' + getIconURIForLinkType(link.additionalLink.type)" :alt="'additional link for ' + link.name" :title="link.additionalLink.description" loading="lazy" />
@@ -83,6 +90,10 @@ const props = defineProps<{
     font-size: 23px;
     color: #3498db;
     text-decoration: underline;
+  }
+  h4.no-link {
+    color: #716e75;
+    text-decoration: none;
   }
 
   p {


### PR DESCRIPTION
Hoping the title is enough for you to accept this Pull Request.

Otherwise, this pull request aims to add **cards without a main website URL** for organizations and clubs which does not have one. For now, only few of them are disabled and seems to be black ships in the herd of white ones (please do not misinterpret this expression) :
- the BDS is disabled, because a building website is not worth any of the other websites that are obsolete for several years, moreover we all expect more effort from its developer (joking, he has already done more than enough)
- Terminat'eirb has also been as "terminated" as its website (and its mandate)
- In the clubs group, only Bill'eirb leads to a 404 page

The pull request is wanted to be accepted once the #35 will be, as it is in the continuity of fixes to both lighten the layouts from the weird channel buttons while including all clubs and organizations in eirb.fr, even if they do not have any website.

![image](https://github.com/user-attachments/assets/3c3866a3-27bb-481e-81d0-5e15c612c110)
![image](https://github.com/user-attachments/assets/b2083476-218d-4734-9e2b-83592827ea9d)

*Ouch*
![image](https://github.com/user-attachments/assets/dd1910af-7195-46da-96f5-f1e30709a551)
